### PR TITLE
Ability to change answer and CSRF tokens

### DIFF
--- a/backend/Upstart/Upstart.Api/Endpoints/AuthEndpoint.cs
+++ b/backend/Upstart/Upstart.Api/Endpoints/AuthEndpoint.cs
@@ -36,7 +36,7 @@ public static class AuthEndpoint
             .Produces(404);
     }
 
-    private static async Task<IResult> Register(RegisterApiRequest request, IAuthenticationService authService, IValidator<RegisterApiRequest> validator, IMapper mapper, ILogger<IAuthenticationService> logger)
+    private static async Task<IResult> Register(RegisterApiRequest request, IAuthenticationService authService, IValidator<RegisterApiRequest> validator, IMapper mapper, ILogger<IAuthenticationService> logger, HttpContext httpContext)
     {
         logger.LogInformation("Registration attempt for email: {Email}", request.Email);
 
@@ -49,9 +49,13 @@ public static class AuthEndpoint
             return Results.BadRequest(validationResult.ToDictionary());
         }
 
+        // Get session ID from cookies if available
+        var sessionId = httpContext.Request.Cookies["upstart_session"];
+
         var serviceRequest = new RegisterRequest(
             request.Email,
-            request.Password
+            request.Password,
+            sessionId
         );
 
         var result = await authService.RegisterAsync(serviceRequest);

--- a/backend/Upstart/Upstart.Api/Endpoints/CsrfEndpoint.cs
+++ b/backend/Upstart/Upstart.Api/Endpoints/CsrfEndpoint.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Antiforgery;
+
+namespace Upstart.Api.Endpoints;
+
+public static class CsrfEndpoint
+{
+    public static void MapCsrfEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/csrf").WithTags("CSRF");
+
+        group.MapGet("/token", GetCsrfToken)
+            .WithName("GetCsrfToken")
+            .WithSummary("Get CSRF token for form submissions")
+            .Produces<CsrfTokenResponse>(200);
+    }
+
+    private static IResult GetCsrfToken(HttpContext httpContext, IAntiforgery antiforgery)
+    {
+        var tokens = antiforgery.GetAndStoreTokens(httpContext);
+        var response = new CsrfTokenResponse(tokens.RequestToken!);
+        return Results.Ok(response);
+    }
+}
+
+public record CsrfTokenResponse(string Token);

--- a/backend/Upstart/Upstart.Api/Endpoints/PollAnswersEndpoint.cs
+++ b/backend/Upstart/Upstart.Api/Endpoints/PollAnswersEndpoint.cs
@@ -18,8 +18,7 @@ public static class PollAnswersEndpoint
             .WithName("CreatePollAnswer")
             .WithSummary("Create a new poll answer")
             .Produces(201)
-            .Produces(400)
-            .RequireAuthorization();
+            .Produces(400);
 
         group.MapGet("/{id:int}", GetPollAnswerById)
             .WithName("GetPollAnswerById")

--- a/backend/Upstart/Upstart.Api/Endpoints/PollStatsEndpoint.cs
+++ b/backend/Upstart/Upstart.Api/Endpoints/PollStatsEndpoint.cs
@@ -57,6 +57,19 @@ public static class PollStatsEndpoint
             .Produces(404)
             .RequireAuthorization();
 
+        group.MapGet("/poll/{pollId:int}/session/me", GetCurrentSessionPollResponse)
+            .WithName("GetCurrentSessionPollResponse")
+            .WithSummary("Get current session's response to a specific poll")
+            .Produces(200)
+            .Produces(404);
+
+        group.MapPut("/{id:int}", UpdatePollStat)
+            .WithName("UpdatePollStat")
+            .WithSummary("Update a poll response")
+            .Produces(200)
+            .Produces(400)
+            .Produces(404);
+
         group.MapGet("/poll/{pollId:int}/results", GetPollResults)
             .WithName("GetPollResults")
             .WithSummary("Get poll results")
@@ -87,7 +100,8 @@ public static class PollStatsEndpoint
             var serviceRequest = new CreatePollStatRequest(
                 request.PollId,
                 request.PollAnswerId,
-                userId
+                userId,
+                null // No session ID for authenticated users
             );
             
             var result = await pollStatService.CreatePollStatAsync(serviceRequest);
@@ -172,6 +186,80 @@ public static class PollStatsEndpoint
         return Results.Ok(result);
     }
 
+    private static async Task<IResult> GetCurrentSessionPollResponse(int pollId, IPollStatService pollStatService, ILogger<IPollStatService> logger, HttpContext httpContext)
+    {
+        var sessionId = httpContext.Request.Cookies["upstart_session"];
+        logger.LogDebug("Retrieved session ID from cookies: {SessionId} for poll ID: {PollId}", sessionId ?? "null", pollId);
+        
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            logger.LogWarning("No session found for poll response request for poll ID: {PollId}", pollId);
+            return Results.NotFound($"No session found for poll response");
+        }
+
+        logger.LogInformation("Getting session poll response for poll ID: {PollId}, session ID: {SessionId}", pollId, sessionId);
+
+        var result = await pollStatService.GetSessionPollResponseAsync(pollId, sessionId);
+        if (result == null)
+        {
+            logger.LogWarning("Poll response not found for poll ID: {PollId}, session ID: {SessionId}", pollId, sessionId);
+            return Results.NotFound($"Poll response not found for poll {pollId} and session {sessionId}");
+        }
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> UpdatePollStat(int id, UpdatePollStatApiRequest request, IPollStatService pollStatService, IValidator<UpdatePollStatApiRequest> validator, ILogger<IPollStatService> logger, HttpContext httpContext)
+    {
+        logger.LogInformation("Updating poll stat with ID: {PollStatId}", id);
+
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            logger.LogWarning("Poll stat update validation failed for ID: {PollStatId}. Errors: {@ValidationErrors}",
+                id, validationResult.Errors);
+            return Results.BadRequest(validationResult.ToDictionary());
+        }
+
+        try
+        {
+            // Try to get user ID if authenticated
+            int? userId = null;
+            try
+            {
+                userId = httpContext.GetUserId();
+            }
+            catch
+            {
+                // User is not authenticated, which is fine for session-based responses
+            }
+
+            // Get session ID for unauthenticated users
+            string? sessionId = null;
+            if (!userId.HasValue)
+            {
+                sessionId = httpContext.Request.Cookies["upstart_session"];
+            }
+
+            var serviceRequest = new UpdatePollStatRequest(id, request.PollAnswerId);
+            
+            var result = await pollStatService.UpdatePollStatAsync(serviceRequest, userId, sessionId);
+
+            logger.LogInformation("Poll stat updated successfully with ID: {PollStatId}", result.Id);
+            return Results.Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning("Poll stat update failed: {ErrorMessage}", ex.Message);
+            return Results.NotFound(ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger.LogWarning("Poll stat update unauthorized: {ErrorMessage}", ex.Message);
+            return Results.Forbid();
+        }
+    }
+
     private static async Task<IResult> DeletePollStat(int id, IPollStatService pollStatService, ILogger<IPollStatService> logger)
     {
         logger.LogInformation("Deleting poll stat with ID: {PollStatId}", id);
@@ -182,7 +270,7 @@ public static class PollStatsEndpoint
         return Results.NoContent();
     }
 
-    private static async Task<IResult> CreateAnonymousPollStat(CreatePollStatApiRequest request, IPollStatService pollStatService, IValidator<CreatePollStatApiRequest> validator, IMapper mapper, ILogger<IPollStatService> logger)
+    private static async Task<IResult> CreateAnonymousPollStat(CreatePollStatApiRequest request, IPollStatService pollStatService, IValidator<CreatePollStatApiRequest> validator, IMapper mapper, ILogger<IPollStatService> logger, HttpContext httpContext)
     {
         logger.LogInformation("Creating anonymous poll stat for poll ID: {PollId}", request.PollId);
 
@@ -196,10 +284,25 @@ public static class PollStatsEndpoint
 
         try
         {
+            // Get or create session ID for unauthenticated users
+            var sessionId = httpContext.Request.Cookies["upstart_session"];
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                sessionId = Guid.NewGuid().ToString();
+                httpContext.Response.Cookies.Append("upstart_session", sessionId, new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = httpContext.Request.IsHttps,
+                    SameSite = SameSiteMode.Lax,
+                    Expires = DateTimeOffset.UtcNow.AddYears(1)
+                });
+            }
+
             var serviceRequest = new CreatePollStatRequest(
                 request.PollId,
                 request.PollAnswerId,
-                null // Anonymous user (no user ID)
+                null, // Anonymous user (no user ID)
+                sessionId
             );
             
             var result = await pollStatService.CreatePollStatAsync(serviceRequest);

--- a/backend/Upstart/Upstart.Api/Models/UpdatePollApiRequest.cs
+++ b/backend/Upstart/Upstart.Api/Models/UpdatePollApiRequest.cs
@@ -4,5 +4,6 @@ public record UpdatePollApiRequest(
     string Question,
     bool IsActive,
     bool IsMultipleChoice,
+    bool RequiresAuthentication,
     DateTime? ExpiresAt
 );

--- a/backend/Upstart/Upstart.Api/Models/UpdatePollStatApiRequest.cs
+++ b/backend/Upstart/Upstart.Api/Models/UpdatePollStatApiRequest.cs
@@ -1,0 +1,5 @@
+namespace Upstart.Api.Models;
+
+public record UpdatePollStatApiRequest(
+    int PollAnswerId
+);

--- a/backend/Upstart/Upstart.Api/Program.cs
+++ b/backend/Upstart/Upstart.Api/Program.cs
@@ -55,7 +55,8 @@ try
         {
             policy.WithOrigins(allowedOrigins)
                   .AllowAnyHeader()
-                  .AllowAnyMethod();
+                  .AllowAnyMethod()
+                  .AllowCredentials();
         });
     });
 
@@ -103,6 +104,16 @@ try
 
     builder.Services.AddAuthorization();
 
+    // Add CSRF protection
+    builder.Services.AddAntiforgery(options =>
+    {
+        options.HeaderName = "X-CSRF-TOKEN";
+        options.Cookie.Name = "__Host-X-CSRF-TOKEN";
+        options.Cookie.SameSite = SameSiteMode.Strict;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        options.Cookie.HttpOnly = true;
+    });
+
     var app = builder.Build();
 
     // Configure the HTTP request pipeline.
@@ -135,6 +146,7 @@ try
     app.UseAuthorization();
 
     // Map endpoints
+    app.MapCsrfEndpoints();
     app.MapAuthEndpoints();
     app.MapUsersEndpoints();
     app.MapPollsEndpoints();

--- a/backend/Upstart/Upstart.Api/Validators/UpdatePollStatApiRequestValidator.cs
+++ b/backend/Upstart/Upstart.Api/Validators/UpdatePollStatApiRequestValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using Upstart.Api.Models;
+
+namespace Upstart.Api.Validators;
+
+public class UpdatePollStatApiRequestValidator : AbstractValidator<UpdatePollStatApiRequest>
+{
+    public UpdatePollStatApiRequestValidator()
+    {
+        RuleFor(x => x.PollAnswerId)
+            .GreaterThan(0)
+            .WithMessage("Poll Answer ID must be greater than 0");
+    }
+}

--- a/backend/Upstart/Upstart.Application/Interfaces/IPollService.cs
+++ b/backend/Upstart/Upstart.Application/Interfaces/IPollService.cs
@@ -11,6 +11,9 @@ public interface IPollService
     Task<IEnumerable<PollModel>> GetAllPollsAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<PollModel>> GetPollsByUserIdAsync(int userId, CancellationToken cancellationToken = default);
     Task<IEnumerable<PollModel>> GetActivePollsAsync(CancellationToken cancellationToken = default);
-    Task<PollModel> UpdatePollAsync(UpdatePollRequest request, CancellationToken cancellationToken = default);
+    Task<PollModel> UpdatePollAsync(UpdatePollRequest request, int userId, CancellationToken cancellationToken = default);
     Task DeletePollAsync(int id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<PollModel>> GetPollsBySessionIdAsync(string sessionId, CancellationToken cancellationToken = default);
+    Task<int> MigratePollsFromSessionToUserAsync(string sessionId, int userId, CancellationToken cancellationToken = default);
+    Task ReplaceAnswersForPollAsync(int pollId, int userId, List<string> newAnswers, CancellationToken cancellationToken = default);
 }

--- a/backend/Upstart/Upstart.Application/Interfaces/IPollStatService.cs
+++ b/backend/Upstart/Upstart.Application/Interfaces/IPollStatService.cs
@@ -10,6 +10,8 @@ public interface IPollStatService
     Task<IEnumerable<PollStatModel>> GetPollStatsByPollIdAsync(int pollId, CancellationToken cancellationToken = default);
     Task<IEnumerable<PollStatModel>> GetPollStatsByUserIdAsync(int userId, CancellationToken cancellationToken = default);
     Task<PollStatModel?> GetUserPollResponseAsync(int pollId, int userId, CancellationToken cancellationToken = default);
+    Task<PollStatModel?> GetSessionPollResponseAsync(int pollId, string sessionId, CancellationToken cancellationToken = default);
+    Task<PollStatModel> UpdatePollStatAsync(UpdatePollStatRequest request, int? userId, string? sessionId, CancellationToken cancellationToken = default);
     Task<IEnumerable<PollStatModel>> GetPollResultsAsync(int pollId, CancellationToken cancellationToken = default);
     Task DeletePollStatAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/backend/Upstart/Upstart.Application/Services/AuthenticationModels.cs
+++ b/backend/Upstart/Upstart.Application/Services/AuthenticationModels.cs
@@ -4,7 +4,8 @@ namespace Upstart.Application.Services;
 
 public record RegisterRequest(
     string Email,
-    string Password
+    string Password,
+    string? SessionId = null
 );
 
 public record LoginRequest(

--- a/backend/Upstart/Upstart.Application/Services/PollService.cs
+++ b/backend/Upstart/Upstart.Application/Services/PollService.cs
@@ -8,11 +8,13 @@ namespace Upstart.Application.Services;
 public class PollService : IPollService
 {
     private readonly IPollsRepository _pollsRepository;
+    private readonly IPollAnswersRepository _pollAnswersRepository;
     private readonly ILogger<PollService> _logger;
 
-    public PollService(IPollsRepository pollsRepository, ILogger<PollService> logger)
+    public PollService(IPollsRepository pollsRepository, IPollAnswersRepository pollAnswersRepository, ILogger<PollService> logger)
     {
         _pollsRepository = pollsRepository;
+        _pollAnswersRepository = pollAnswersRepository;
         _logger = logger;
     }
 
@@ -24,6 +26,7 @@ public class PollService : IPollService
         {
             PollGuid = Guid.NewGuid().ToString(),
             UserId = request.UserId,
+            SessionId = request.SessionId,
             Question = request.Question,
             IsActive = request.IsActive,
             IsMultipleChoice = request.IsMultipleChoice,
@@ -60,19 +63,32 @@ public class PollService : IPollService
         return await _pollsRepository.GetActiveAsync();
     }
 
-    public async Task<PollModel> UpdatePollAsync(UpdatePollRequest request, CancellationToken cancellationToken = default)
+    public async Task<PollModel> UpdatePollAsync(UpdatePollRequest request, int userId, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Updating poll with ID: {PollId}", request.Id);
+        _logger.LogDebug("Updating poll with ID: {PollId} by user: {UserId}", request.Id, userId);
 
         var existingPoll = await _pollsRepository.GetByIdAsync(request.Id);
         if (existingPoll == null)
         {
+            _logger.LogWarning("Poll with ID {PollId} not found", request.Id);
             throw new InvalidOperationException($"Poll with ID '{request.Id}' not found.");
+        }
+
+        _logger.LogDebug("Found poll with ID: {PollId}, UserId: {PollUserId}, requesting user: {RequestingUserId}", 
+            existingPoll.Id, existingPoll.UserId, userId);
+
+        // Check ownership - user can only edit their own polls
+        if (existingPoll.UserId != userId)
+        {
+            _logger.LogWarning("User {UserId} is not authorized to edit poll {PollId} (owned by user {PollUserId})", 
+                userId, request.Id, existingPoll.UserId);
+            throw new UnauthorizedAccessException($"User {userId} is not authorized to edit poll {request.Id}.");
         }
 
         existingPoll.Question = request.Question;
         existingPoll.IsActive = request.IsActive;
         existingPoll.IsMultipleChoice = request.IsMultipleChoice;
+        existingPoll.RequiresAuthentication = request.RequiresAuthentication;
         existingPoll.ExpiresAt = request.ExpiresAt?.ToUniversalTime();
         existingPoll.UpdatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
 
@@ -84,10 +100,61 @@ public class PollService : IPollService
         _logger.LogDebug("Deleting poll with ID: {PollId}", id);
         await _pollsRepository.DeleteAsync(id);
     }
+
+    public async Task<IEnumerable<PollModel>> GetPollsBySessionIdAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        return await _pollsRepository.GetBySessionIdAsync(sessionId);
+    }
+
+    public async Task<int> MigratePollsFromSessionToUserAsync(string sessionId, int userId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Migrating polls from session {SessionId} to user {UserId}", sessionId, userId);
+        return await _pollsRepository.MigratePollsFromSessionToUserAsync(sessionId, userId);
+    }
+
+    public async Task ReplaceAnswersForPollAsync(int pollId, int userId, List<string> newAnswers, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Replacing answers for poll ID: {PollId} by user: {UserId}", pollId, userId);
+
+        // First verify the user owns the poll
+        var poll = await _pollsRepository.GetByIdAsync(pollId);
+        if (poll == null)
+        {
+            throw new InvalidOperationException($"Poll with ID '{pollId}' not found.");
+        }
+
+        if (poll.UserId != userId)
+        {
+            throw new UnauthorizedAccessException($"User {userId} is not authorized to edit poll {pollId}.");
+        }
+
+        // Get current answers and delete them
+        var currentAnswers = await _pollAnswersRepository.GetByPollIdAsync(pollId);
+        foreach (var answer in currentAnswers)
+        {
+            await _pollAnswersRepository.DeleteAsync(answer.Id);
+        }
+
+        // Create new answers
+        for (int i = 0; i < newAnswers.Count; i++)
+        {
+            var newAnswer = new PollAnswerModel
+            {
+                PollId = pollId,
+                AnswerText = newAnswers[i].Trim(),
+                DisplayOrder = i + 1,
+                CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc),
+                UpdatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc)
+            };
+            
+            await _pollAnswersRepository.CreateAsync(newAnswer);
+        }
+    }
 }
 
 public record CreatePollRequest(
-    int UserId,
+    int? UserId,
+    string? SessionId,
     string Question,
     bool IsActive = true,
     bool IsMultipleChoice = false,
@@ -99,5 +166,6 @@ public record UpdatePollRequest(
     string Question,
     bool IsActive,
     bool IsMultipleChoice,
+    bool RequiresAuthentication,
     DateTime? ExpiresAt
 );

--- a/backend/Upstart/Upstart.Domain/Interfaces/IPollStatsRepository.cs
+++ b/backend/Upstart/Upstart.Domain/Interfaces/IPollStatsRepository.cs
@@ -9,6 +9,8 @@ public interface IPollStatsRepository
     Task<IEnumerable<PollStatModel>> GetByPollIdAsync(int pollId);
     Task<IEnumerable<PollStatModel>> GetByUserIdAsync(int userId);
     Task<PollStatModel?> GetUserResponseAsync(int pollId, int userId);
+    Task<PollStatModel?> GetSessionResponseAsync(int pollId, string sessionId);
+    Task<PollStatModel> UpdateAsync(PollStatModel pollStat);
     Task<IEnumerable<PollStatModel>> GetPollResultsAsync(int pollId);
     Task DeleteAsync(int id);
     Task DeleteByPollIdAsync(int pollId);

--- a/backend/Upstart/Upstart.Domain/Interfaces/IPollsRepository.cs
+++ b/backend/Upstart/Upstart.Domain/Interfaces/IPollsRepository.cs
@@ -12,4 +12,6 @@ public interface IPollsRepository
     Task<IEnumerable<PollModel>> GetActiveAsync();
     Task<PollModel> UpdateAsync(PollModel poll);
     Task DeleteAsync(int id);
+    Task<IEnumerable<PollModel>> GetBySessionIdAsync(string sessionId);
+    Task<int> MigratePollsFromSessionToUserAsync(string sessionId, int userId);
 }

--- a/backend/Upstart/Upstart.Domain/Models/PollModel.cs
+++ b/backend/Upstart/Upstart.Domain/Models/PollModel.cs
@@ -4,7 +4,8 @@ public class PollModel
 {
     public int Id { get; set; }
     public string PollGuid { get; set; } = string.Empty;
-    public int UserId { get; set; }
+    public int? UserId { get; set; }
+    public string? SessionId { get; set; }
     public string Question { get; set; } = string.Empty;
     public bool IsActive { get; set; } = true;
     public bool IsMultipleChoice { get; set; } = false;

--- a/backend/Upstart/Upstart.Domain/Models/PollStatModel.cs
+++ b/backend/Upstart/Upstart.Domain/Models/PollStatModel.cs
@@ -6,6 +6,7 @@ public class PollStatModel
     public int PollId { get; set; }
     public int PollAnswerId { get; set; }
     public int? UserId { get; set; }
+    public string? SessionId { get; set; }
     public DateTime SelectedAt { get; set; }
     public PollModel? Poll { get; set; }
     public PollAnswerModel? PollAnswer { get; set; }

--- a/backend/Upstart/Upstart.Persistence/Entitities/PollEntity.cs
+++ b/backend/Upstart/Upstart.Persistence/Entitities/PollEntity.cs
@@ -15,8 +15,11 @@ public class PollEntity
     public string PollGuid { get; set; } = string.Empty;
 
     [Column("user_id")]
-    [Required]
-    public int UserId { get; set; }
+    public int? UserId { get; set; }
+
+    [Column("session_id")]
+    [MaxLength(255)]
+    public string? SessionId { get; set; }
 
     [Column("question")]
     [MaxLength(500)]
@@ -42,7 +45,7 @@ public class PollEntity
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
     [ForeignKey("UserId")]
-    public UserEntity User { get; set; } = null!;
+    public UserEntity? User { get; set; }
 
     public ICollection<PollAnswerEntity> Answers { get; set; } = new List<PollAnswerEntity>();
 

--- a/backend/Upstart/Upstart.Persistence/Entitities/PollStatEntity.cs
+++ b/backend/Upstart/Upstart.Persistence/Entitities/PollStatEntity.cs
@@ -21,6 +21,10 @@ public class PollStatEntity
     [Column("user_id")]
     public int? UserId { get; set; }
 
+    [Column("session_id")]
+    [MaxLength(255)]
+    public string? SessionId { get; set; }
+
     [Column("selected_at")]
     public DateTime SelectedAt { get; set; } = DateTime.UtcNow;
 

--- a/backend/Upstart/Upstart.Persistence/Migrations/20250807025408_cookies.Designer.cs
+++ b/backend/Upstart/Upstart.Persistence/Migrations/20250807025408_cookies.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Upstart.Persistence.Data;
@@ -11,9 +12,11 @@ using Upstart.Persistence.Data;
 namespace Upstart.Persistence.Migrations
 {
     [DbContext(typeof(UpstartDbContext))]
-    partial class UpstartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250807025408_cookies")]
+    partial class cookies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -149,11 +152,6 @@ namespace Upstart.Persistence.Migrations
                     b.Property<DateTime>("SelectedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("selected_at");
-
-                    b.Property<string>("SessionId")
-                        .HasMaxLength(255)
-                        .HasColumnType("character varying(255)")
-                        .HasColumnName("session_id");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("integer")

--- a/backend/Upstart/Upstart.Persistence/Migrations/20250807025408_cookies.cs
+++ b/backend/Upstart/Upstart.Persistence/Migrations/20250807025408_cookies.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Upstart.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class cookies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "last_name",
+                table: "users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "first_name",
+                table: "users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "user_id",
+                table: "polls",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<string>(
+                name: "session_id",
+                table: "polls",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "session_id",
+                table: "polls");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "last_name",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "first_name",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "user_id",
+                table: "polls",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/Upstart/Upstart.Persistence/Migrations/20250807034122_statsessionid.Designer.cs
+++ b/backend/Upstart/Upstart.Persistence/Migrations/20250807034122_statsessionid.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Upstart.Persistence.Data;
@@ -11,9 +12,11 @@ using Upstart.Persistence.Data;
 namespace Upstart.Persistence.Migrations
 {
     [DbContext(typeof(UpstartDbContext))]
-    partial class UpstartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250807034122_statsessionid")]
+    partial class statsessionid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Upstart/Upstart.Persistence/Migrations/20250807034122_statsessionid.cs
+++ b/backend/Upstart/Upstart.Persistence/Migrations/20250807034122_statsessionid.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Upstart.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class statsessionid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "session_id",
+                table: "poll_stats",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "session_id",
+                table: "poll_stats");
+        }
+    }
+}

--- a/flyway/upstart/migrations/V5__cookies.sql
+++ b/flyway/upstart/migrations/V5__cookies.sql
@@ -1,0 +1,5 @@
+-- Flyway migration: cookies
+-- Generated from EF Core migration on 2025-08-06 21:54:10
+-- Description: cookies
+ALTER TABLE polls ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE polls ADD session_id character varying(255);

--- a/flyway/upstart/migrations/V6__statsessionid.sql
+++ b/flyway/upstart/migrations/V6__statsessionid.sql
@@ -1,0 +1,5 @@
+-- Flyway migration: statsessionid
+-- Generated from EF Core migration on 2025-08-06 22:41:24
+-- Description: statsessionid
+
+ALTER TABLE poll_stats ADD session_id character varying(255);

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -27,8 +27,8 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin }) => {
     setError('');
 
     // Basic validation
-    if (formData.password.length < 6) {
-      setError('Password must be at least 6 characters long');
+    if (formData.password.length < 8) {
+      setError('Password must be at least 8 characters long');
       setIsLoading(false);
       return;
     }
@@ -98,7 +98,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin }) => {
                 )}
               </button>
             }
-            helperText="Minimum 6 characters"
+            helperText="Minimum 8 characters"
             required
           />
 

--- a/frontend/src/components/pages/PollsPage.tsx
+++ b/frontend/src/components/pages/PollsPage.tsx
@@ -7,10 +7,12 @@ import {
   TrashIcon,
   ShareIcon,
   ClockIcon,
-  CheckCircleIcon
+  CheckCircleIcon,
+  PencilIcon
 } from '@heroicons/react/24/outline';
 import Button from '../ui/Button';
 import Card from '../ui/Card';
+import PollEditForm from '../PollEditForm';
 import { Poll } from '../../types';
 import { pollsAPI } from '../../services/api';
 
@@ -23,6 +25,7 @@ const PollsPage: React.FC<PollsPageProps> = ({ onCreatePoll, onViewPoll }) => {
   const [polls, setPolls] = useState<Poll[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingPollId, setDeletingPollId] = useState<number | null>(null);
+  const [editingPoll, setEditingPoll] = useState<Poll | null>(null);
 
   useEffect(() => {
     fetchUserPolls();
@@ -66,6 +69,15 @@ const PollsPage: React.FC<PollsPageProps> = ({ onCreatePoll, onViewPoll }) => {
       // Fallback for browsers that don't support clipboard API
       prompt('Copy this link to share your poll:', pollUrl);
     }
+  };
+
+  const handleEditPoll = (poll: Poll) => {
+    setEditingPoll(poll);
+  };
+
+  const handlePollUpdated = (updatedPoll: Poll) => {
+    setPolls(polls.map(poll => poll.id === updatedPoll.id ? updatedPoll : poll));
+    setEditingPoll(null);
   };
 
   const formatDate = (dateString: string) => {
@@ -267,6 +279,15 @@ const PollsPage: React.FC<PollsPageProps> = ({ onCreatePoll, onViewPoll }) => {
                       <Button
                         variant="ghost"
                         size="sm"
+                        onClick={() => handleEditPoll(poll)}
+                        className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+                      >
+                        <PencilIcon className="w-4 h-4" />
+                      </Button>
+                      
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         onClick={() => handleSharePoll(poll.pollGuid)}
                       >
                         <ShareIcon className="w-4 h-4" />
@@ -292,6 +313,15 @@ const PollsPage: React.FC<PollsPageProps> = ({ onCreatePoll, onViewPoll }) => {
             );
           })}
         </div>
+      )}
+
+      {/* Edit Poll Modal */}
+      {editingPoll && (
+        <PollEditForm
+          poll={editingPoll}
+          onClose={() => setEditingPoll(null)}
+          onPollUpdated={handlePollUpdated}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/pages/PublicLandingPage.tsx
+++ b/frontend/src/components/pages/PublicLandingPage.tsx
@@ -3,12 +3,15 @@ import { motion } from 'framer-motion';
 import { 
   ChartPieIcon, 
   PlusIcon,
-  ArrowRightIcon 
+  ArrowRightIcon,
+  AdjustmentsHorizontalIcon,
+  ChevronDownIcon
 } from '@heroicons/react/24/outline';
 import Button from '../ui/Button';
 import PollCard from '../poll/PollCard';
 import LoginForm from '../auth/LoginForm';
 import RegisterForm from '../auth/RegisterForm';
+import PollCreationForm from '../PollCreationForm';
 import { Poll } from '../../types';
 import { pollsAPI } from '../../services/api';
 
@@ -16,16 +19,25 @@ interface PublicLandingPageProps {
   onViewPoll: (pollGuid: string) => void;
 }
 
+type SortOption = 'newest' | 'votes' | 'expiring';
+
 const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => {
   const [polls, setPolls] = useState<Poll[]>([]);
+  const [allPolls, setAllPolls] = useState<Poll[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showAuth, setShowAuth] = useState<'login' | 'register' | null>(null);
+  const [showCreatePoll, setShowCreatePoll] = useState(false);
+  const [showAllPolls, setShowAllPolls] = useState(false);
+  const [sortBy, setSortBy] = useState<SortOption>('newest');
+  const [showSortDropdown, setShowSortDropdown] = useState(false);
 
   useEffect(() => {
     const fetchPublicPolls = async () => {
       try {
         const publicPolls = await pollsAPI.getPublicPolls();
-        setPolls(publicPolls.slice(0, 6)); // Show first 6 polls
+        const sortedPolls = sortPolls(publicPolls, sortBy);
+        setAllPolls(publicPolls);
+        setPolls(sortedPolls.slice(0, 6)); // Show first 6 polls initially
       } catch (error) {
         console.error('Failed to fetch public polls:', error);
       } finally {
@@ -35,6 +47,86 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
 
     fetchPublicPolls();
   }, []);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (showSortDropdown) {
+        const target = event.target as Element;
+        if (!target.closest('.sort-dropdown')) {
+          setShowSortDropdown(false);
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showSortDropdown]);
+
+  const handlePollCreated = () => {
+    // Refresh polls after creation
+    setPolls([]);
+    setIsLoading(true);
+    const fetchPublicPolls = async () => {
+      try {
+        const publicPolls = await pollsAPI.getPublicPolls();
+        const sortedPolls = sortPolls(publicPolls, sortBy);
+        setAllPolls(publicPolls);
+        setPolls(showAllPolls ? sortedPolls : sortedPolls.slice(0, 6));
+      } catch (error) {
+        console.error('Failed to fetch public polls:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchPublicPolls();
+  };
+
+  const sortPolls = (pollsToSort: Poll[], sortOption: SortOption): Poll[] => {
+    const sorted = [...pollsToSort];
+    
+    switch (sortOption) {
+      case 'votes':
+        return sorted.sort((a, b) => {
+          const aVotes = a.stats?.length || 0;
+          const bVotes = b.stats?.length || 0;
+          return bVotes - aVotes; // Most votes first
+        });
+      case 'expiring':
+        return sorted.sort((a, b) => {
+          // Polls without expiry go to the end
+          if (!a.expiresAt && !b.expiresAt) return 0;
+          if (!a.expiresAt) return 1;
+          if (!b.expiresAt) return -1;
+          
+          const aDate = new Date(a.expiresAt);
+          const bDate = new Date(b.expiresAt);
+          return aDate.getTime() - bDate.getTime(); // Expiring soonest first
+        });
+      case 'newest':
+      default:
+        return sorted.sort((a, b) => {
+          const aDate = new Date(a.createdAt);
+          const bDate = new Date(b.createdAt);
+          return bDate.getTime() - aDate.getTime(); // Newest first
+        });
+    }
+  };
+
+  const applySort = (sortOption: SortOption) => {
+    const sortedPolls = sortPolls(allPolls, sortOption);
+    setPolls(showAllPolls ? sortedPolls : sortedPolls.slice(0, 6));
+    setSortBy(sortOption);
+    setShowSortDropdown(false);
+  };
+
+  const toggleShowAllPolls = () => {
+    const newShowAll = !showAllPolls;
+    setShowAllPolls(newShowAll);
+    
+    const sortedPolls = sortPolls(allPolls, sortBy);
+    setPolls(newShowAll ? sortedPolls : sortedPolls.slice(0, 6));
+  };
 
 
   if (showAuth) {
@@ -110,7 +202,7 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
               <Button
                 variant="primary"
                 size="lg"
-                onClick={() => setShowAuth('register')}
+                onClick={() => setShowCreatePoll(true)}
                 className="flex items-center gap-2"
               >
                 <PlusIcon className="w-5 h-5" />
@@ -119,10 +211,10 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
               <Button
                 variant="outline"
                 size="lg"
-                onClick={() => setShowAuth('login')}
+                onClick={() => setShowAuth('register')}
                 className="flex items-center gap-2"
               >
-                Sign In
+                Sign Up for More Features
                 <ArrowRightIcon className="w-5 h-5" />
               </Button>
             </div>
@@ -132,36 +224,103 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
 
 
       {/* Recent Polls Section */}
-      <section className="py-16 px-4 sm:px-6 lg:px-8">
+      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-gray-50 border-t border-gray-100">
         <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-gray-900 font-montserrat mb-4">
-              Recent Public Polls
+          <div className="text-center mb-16">
+            <div className="inline-flex items-center justify-center w-12 h-12 bg-primary-100 rounded-xl mb-6">
+              <ChartPieIcon className="w-6 h-6 text-primary-600" />
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 font-montserrat mb-4">
+              {showAllPolls ? 'All Public Polls' : 'Recent Public Polls'}
             </h2>
-            <p className="text-gray-600 font-montserrat text-lg">
-              See what others are asking about
+            <p className="text-gray-600 font-montserrat text-lg max-w-2xl mx-auto mb-8">
+              See what others are asking about and join the conversation
             </p>
+            
+            {/* Sort Options */}
+            <div className="flex justify-center">
+              <div className="relative sort-dropdown">
+                <button
+                  onClick={() => setShowSortDropdown(!showSortDropdown)}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors"
+                >
+                  <AdjustmentsHorizontalIcon className="w-4 h-4" />
+                  Sort by: {
+                    sortBy === 'newest' ? 'Newest' :
+                    sortBy === 'votes' ? 'Most Votes' :
+                    'Expiring Soon'
+                  }
+                  <ChevronDownIcon className={`w-4 h-4 transition-transform ${showSortDropdown ? 'rotate-180' : ''}`} />
+                </button>
+                
+                {showSortDropdown && (
+                  <div className="absolute top-full mt-2 left-1/2 transform -translate-x-1/2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
+                    <div className="py-2">
+                      <button
+                        onClick={() => applySort('newest')}
+                        className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${sortBy === 'newest' ? 'text-primary-600 bg-primary-50' : 'text-gray-700'}`}
+                      >
+                        Newest First
+                      </button>
+                      <button
+                        onClick={() => applySort('votes')}
+                        className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${sortBy === 'votes' ? 'text-primary-600 bg-primary-50' : 'text-gray-700'}`}
+                      >
+                        Most Votes
+                      </button>
+                      <button
+                        onClick={() => applySort('expiring')}
+                        className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${sortBy === 'expiring' ? 'text-primary-600 bg-primary-50' : 'text-gray-700'}`}
+                      >
+                        Expiring Soon
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
 
           {isLoading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {Array.from({ length: 6 }).map((_, index) => (
-                <div key={index} className="h-64 bg-gray-200 rounded-upstart animate-pulse"></div>
+                <div key={index} className="h-64 bg-white rounded-upstart shadow-sm border border-gray-100 animate-pulse"></div>
               ))}
             </div>
           ) : polls.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {polls.map((poll) => (
-                <motion.div
-                  key={poll.id}
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.3 }}
-                >
-                  <PollCard poll={poll} onViewPoll={onViewPoll} />
-                </motion.div>
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {polls.map((poll) => (
+                  <motion.div
+                    key={poll.id}
+                    initial={{ opacity: 0, scale: 0.95 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: 0.3 }}
+                  >
+                    <PollCard poll={poll} onViewPoll={onViewPoll} />
+                  </motion.div>
+                ))}
+              </div>
+              
+              {allPolls.length > 6 && (
+                <div className="text-center mt-8">
+                  <Button
+                    variant="outline"
+                    onClick={toggleShowAllPolls}
+                    className="flex items-center gap-2 mx-auto"
+                  >
+                    {showAllPolls ? (
+                      <>Show Less</>
+                    ) : (
+                      <>
+                        View All {allPolls.length} Polls
+                        <ArrowRightIcon className="w-4 h-4" />
+                      </>
+                    )}
+                  </Button>
+                </div>
+              )}
+            </>
           ) : (
             <div className="text-center py-12">
               <ChartPieIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
@@ -174,13 +333,14 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
       </section>
 
       {/* CTA Section */}
-      <section className="py-16 px-4 sm:px-6 lg:px-8 bg-primary-600">
-        <div className="max-w-4xl mx-auto text-center">
+      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-r from-primary-600 to-primary-700 relative overflow-hidden">
+        <div className="absolute inset-0 bg-black/10"></div>
+        <div className="max-w-4xl mx-auto text-center relative z-10">
           <h2 className="text-3xl font-bold text-white font-montserrat mb-4">
             Ready to Get Started?
           </h2>
           <p className="text-primary-100 font-montserrat text-lg mb-8">
-            Join thousands of users who trust UpPoll for their polling needs
+            Join users who trust UpPoll for their polling needs
           </p>
           <Button
             variant="secondary"
@@ -192,6 +352,21 @@ const PublicLandingPage: React.FC<PublicLandingPageProps> = ({ onViewPoll }) => 
           </Button>
         </div>
       </section>
+
+      {/* Poll Creation Modal */}
+      {showCreatePoll && (
+        <PollCreationForm
+          onClose={() => setShowCreatePoll(false)}
+          onPollCreated={() => {
+            setShowCreatePoll(false);
+            handlePollCreated();
+            // Show a message encouraging registration
+            setTimeout(() => {
+              setShowAuth('register');
+            }, 500);
+          }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This pull request introduces significant improvements to poll and session management, adds CSRF protection, and enhances API endpoints for better support of both authenticated and anonymous users. The main changes include session-based tracking for unauthenticated users, new endpoints for poll management, and the integration of CSRF tokens for improved security.

**Session and Poll Management Enhancements:**

- Added logic to generate and use a persistent `upstart_session` cookie for unauthenticated users throughout poll creation, answering, and stat tracking, ensuring anonymous users can be consistently identified. [[1]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fR75-R129) [[2]](diffhunk://#diff-7b817b23f1739e696cc57b5def97f5ca509eed6e89f3e95e492a070d5b6cd078L185-R273) [[3]](diffhunk://#diff-7b817b23f1739e696cc57b5def97f5ca509eed6e89f3e95e492a070d5b6cd078R287-R305)
- Updated poll creation and stat endpoints to accept both authenticated user IDs and session IDs, allowing seamless support for both user types. [[1]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fR75-R129) [[2]](diffhunk://#diff-7b817b23f1739e696cc57b5def97f5ca509eed6e89f3e95e492a070d5b6cd078L90-R104) [[3]](diffhunk://#diff-9596b31f3fe4d1c754e6814a276cd4ff2a4dbc481d0e4f33706037753f0248d9R52-R58)
- Introduced new endpoints for updating poll stats and retrieving the current session's poll response, enabling users to update their answers and fetch their own poll responses. [[1]](diffhunk://#diff-7b817b23f1739e696cc57b5def97f5ca509eed6e89f3e95e492a070d5b6cd078R60-R72) [[2]](diffhunk://#diff-7b817b23f1739e696cc57b5def97f5ca509eed6e89f3e95e492a070d5b6cd078R189-R262) [[3]](diffhunk://#diff-16d5081bd1d656823812f7b4fcca2267ed262ea2aa995d47c3ece2e41d6b7eb9R1-R5) [[4]](diffhunk://#diff-bdd8c6dba7b8c4eff2e4084911883c914836d5cdf2f0d31483fe9da8e0e92d32R1-R14)

**API Endpoint and Model Changes:**

- Added a new endpoint to allow replacing all answers for a poll, with proper authorization and error handling. [[1]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fR75-R129) [[2]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fR256-R279)
- Enhanced the `UpdatePollApiRequest` model and update logic to support a `RequiresAuthentication` flag, and enforced authorization checks on poll updates and answer replacements. [[1]](diffhunk://#diff-30fdbb2d785887242f726f890828b99ce7331528dfe292e47821f97e54d2d190R7) [[2]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fL178-R218) [[3]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fL190-R244)

**Security Improvements:**

- Integrated CSRF protection by configuring antiforgery services, creating a dedicated CSRF token endpoint, and updating CORS settings to allow credentials. [[1]](diffhunk://#diff-c9e88906a772c4946b1157135f0aa1690d1abe0501611a55c566a54ff4db3fe0R107-R116) [[2]](diffhunk://#diff-1c067efded224328a132f11743cae9bd0b2cc725df085f75b0dfd8aec5affafcR1-R25) [[3]](diffhunk://#diff-c9e88906a772c4946b1157135f0aa1690d1abe0501611a55c566a54ff4db3fe0L58-R59) [[4]](diffhunk://#diff-c9e88906a772c4946b1157135f0aa1690d1abe0501611a55c566a54ff4db3fe0R149)

**Authorization and Validation Adjustments:**

- Removed the requirement for authorization on poll and poll answer creation endpoints, allowing anonymous users to participate using session IDs. [[1]](diffhunk://#diff-2a2230260357b184a08603319632dfcb8cdc51ea20cb81493efb4c9cb463237fL21-R21) [[2]](diffhunk://#diff-efaddb544439d33f530c9bd5781593ac9b7f1681bdd93be435fe13241ab62295L21-R21)
- Added new validators for poll stat updates to ensure data integrity.

These changes collectively make the API more flexible for both authenticated and anonymous users, improve poll management capabilities, and enhance security through CSRF protection.